### PR TITLE
Don't sort by starred when saving saved queries

### DIFF
--- a/src/components/searchable-data.tsx
+++ b/src/components/searchable-data.tsx
@@ -72,7 +72,7 @@ export function SearchableData({ data }: { data: PagesAndMeta }) {
       try {
         const ast = alasql.parse(query);
         const pretty = fixDoubleAliases(
-          ast.toString().replace("FROM $0 AS default", "FROM ?")
+          ast.toString().replace("FROM $0 AS default", "FROM ?"),
         );
         if (pretty !== query) {
           setPossiblePrettySQL(pretty);
@@ -111,7 +111,7 @@ export function SearchableData({ data }: { data: PagesAndMeta }) {
       process.env.NODE_ENV === "development" ? sessionStorage : localStorage;
     try {
       let previous = JSON.parse(
-        storage.getItem("saved_queries") || "[]"
+        storage.getItem("saved_queries") || "[]",
       ) as SavedQuery[];
       if (!Array.isArray(previous)) {
         previous = [];
@@ -228,7 +228,7 @@ export function SearchableData({ data }: { data: PagesAndMeta }) {
           setSavedQueries((prevState) =>
             prevState.filter((entry) => {
               return !includeStarred && entry.star;
-            })
+            }),
           );
         }}
         possibleKeys={possibleKeys}

--- a/src/components/searchable-data.tsx
+++ b/src/components/searchable-data.tsx
@@ -72,7 +72,7 @@ export function SearchableData({ data }: { data: PagesAndMeta }) {
       try {
         const ast = alasql.parse(query);
         const pretty = fixDoubleAliases(
-          ast.toString().replace("FROM $0 AS default", "FROM ?"),
+          ast.toString().replace("FROM $0 AS default", "FROM ?")
         );
         if (pretty !== query) {
           setPossiblePrettySQL(pretty);
@@ -111,7 +111,7 @@ export function SearchableData({ data }: { data: PagesAndMeta }) {
       process.env.NODE_ENV === "development" ? sessionStorage : localStorage;
     try {
       let previous = JSON.parse(
-        storage.getItem("saved_queries") || "[]",
+        storage.getItem("saved_queries") || "[]"
       ) as SavedQuery[];
       if (!Array.isArray(previous)) {
         previous = [];
@@ -141,14 +141,7 @@ export function SearchableData({ data }: { data: PagesAndMeta }) {
     const storage =
       process.env.NODE_ENV === "development" ? sessionStorage : localStorage;
     try {
-      storage.setItem(
-        "saved_queries",
-        JSON.stringify(
-          savedQueries.sort(
-            (a, b) => Number(Boolean(b.star)) - Number(Boolean(a.star)),
-          ),
-        ),
-      );
+      storage.setItem("saved_queries", JSON.stringify(savedQueries));
     } catch (err) {
       if (process.env.NODE_ENV === "development") {
         throw err;
@@ -235,7 +228,7 @@ export function SearchableData({ data }: { data: PagesAndMeta }) {
           setSavedQueries((prevState) =>
             prevState.filter((entry) => {
               return !includeStarred && entry.star;
-            }),
+            })
           );
         }}
         possibleKeys={possibleKeys}


### PR DESCRIPTION
When a new query is saved to the local storage, it first re-sorts them so that the starred ones come before the not-starred ones. 
The intention of that was originally so that when the local storage exceed 50, we prefer to save the starred ones. 

The problem with that is that the most recently saved query isn't the most recent one. 
Suppose you have 3 queries

1. SELECT foo  (most recent)
2. SELECT bar (starred)
3. SELECT buzz 

When it saved these queries to local storage, it would rearrange the sort to become:

1. SELECT bar (starred)
2. SELECT foo 
3. SELECT buzz 

But the problem is that when you start a fresh new session, it would load the first and default query by taking the 0th saved query. In the above case, that would be `SELECT bar` even though that's not the most recently used. 